### PR TITLE
Fix transaction overriding by using setTransactionName

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ module.exports = function (newrelic, opts) {
 	}
 
 	function setTransactionName(method, path) {
-		newrelic.agent.getTransaction().partialName = parseTransactionName(method, path);
+		newrelic.setTransactionName(parseTransactionName(method, path));
 	}
 
 	return function* koaNewrelic(next) {


### PR DESCRIPTION
Even when `this._matchedRoute` (@see #1)  is well defined i still get transaction /*. Here is what i finally found to fix the issue.
