### PR TITLE
Travis integration + lint bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+
+cache:
+  directories:
+    - node_modules
+
+node_js:
+  - stable
+
+env:
+  - CMD=test
+  - CMD=lint
+
+script: npm run $CMD

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const DEFAULT_STATIC_EXTENSIONS = [
 	'html'
 ];
 
-const extRegExp = /\/[^\/]+\.(\w+)$/;
+const extRegExp = /\/[^/]+\.(\w+)$/;
 
 let wrappedFunctions = [];
 
@@ -175,7 +175,6 @@ module.exports = function (newrelic, opts) {
 					let extensions = Array.isArray(opts.staticExtensions) ? opts.staticExtensions : DEFAULT_STATIC_EXTENSIONS;
 					if (extensions.indexOf(ext) !== -1) {
 						setTransactionName(ctx.method, '/*.' + ext);
-						return;
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^1.10.3",
-    "eslint-config-aftership": "^1.5.0",
+    "eslint": "^3.13.0",
+    "eslint-config-aftership": "^3.2.1",
     "koa": "^1.2.0",
     "koa-router": "^5.4.0",
     "mocha": "^2.3.4",

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable no-empty-function */
+
 const KoaNewrelic = require('../index');
 
 const koa = require('koa');
@@ -44,7 +46,7 @@ describe('koa-newrelic route mapping', function () {
 
 		app.use(koaNewrelic);
 		router.use(route, function* () {
-			return;
+
 		});
 
 		app.use(router.routes());
@@ -60,7 +62,7 @@ describe('koa-newrelic route mapping', function () {
 	it('should let newrelic transaction name untouched if no matched route', function (done) {
 		app.use(koaNewrelic);
 		router.use(function* () {
-			return;
+
 		});
 
 		app.use(router.routes());
@@ -135,7 +137,7 @@ describe('koa-newrelic group static resouces', function () {
 		app.use(koaNewrelic);
 
 		router.use('/test/:file', function* () {
-			return;
+
 		});
 
 		app.use(router.routes());
@@ -198,7 +200,7 @@ describe('koa-newrelic custom transaction metric name', function () {
 	it('should set newrelic transaction name in custom way', function (done) {
 		app.use(koaNewrelic);
 		router.use('/test/:id', function* () {
-			return;
+
 		});
 
 		app.use(router.routes());
@@ -236,7 +238,7 @@ describe('koa-newrelic middleware traces', function () {
 		});
 
 		app.use(function* middlewareC() {
-			return;
+
 		});
 
 		request(app.listen())
@@ -259,7 +261,7 @@ describe('koa-newrelic middleware traces', function () {
 		router.get('/test/:id', function* middlewareB(next) {
 			yield next;
 		}, function* middlewareC() {
-			return;
+
 		});
 
 		app.use(router.routes());


### PR DESCRIPTION
This sets up the travis integration. See an example of the first build here:

https://travis-ci.org/AfterShip/koa-newrelic/builds/190054388

As expected, the `test` command fails. `lint` works.

~You will still have to log in to Travis and enable the integration for this project. This just sets up the config file.~ Seems like travis is already enabled for this repo :+1: 