### PR TITLE
hot fix: new option "usePathAsDefaultRoute" to set newrelic transaction name before await next

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ module.exports = function (newrelic, opts) {
 	}
 
 	return async function koaNewrelic(ctx, next) {
-		if (opts.preSetTransaction) {
+		if (opts.usePathAsDefaultRoute) {
 			setTransactionName(ctx.method, ctx.path);
 		}
 

--- a/index.js
+++ b/index.js
@@ -151,6 +151,10 @@ module.exports = function (newrelic, opts) {
 	}
 
 	return async function koaNewrelic(ctx, next) {
+		if (opts.preSetTransaction) {
+			setTransactionName(ctx.method, ctx.path);
+		}
+
 		await next();
 
 		if (ctx._matchedRoute) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koa-newrelic",
   "description": "Koa middleware to allow Newrelic monitor Koa applications",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/AfterShip/koa-newrelic",
   "author": {
     "name": "AfterShip",


### PR DESCRIPTION
Currently,  2.0.0 version can't log the transaction for each router. This PR is a hotfix to solve this issue.
Please help publish. @yangaobo 